### PR TITLE
Interface Segregation Principle - Example.

### DIFF
--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp.sln
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UDemy_DesignnPattersAndPrinciples_ConsoleApp", "UDemy_DesignnPattersAndPrinciples_ConsoleApp\UDemy_DesignnPattersAndPrinciples_ConsoleApp.csproj", "{2B034741-427C-4412-A0EB-D6DD3E08275A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UDemy_DesignnPattersAndPrinciples_ConsoleApp", "UDemy_DesignnPattersAndPrinciples_ConsoleApp\UDemy_DesignnPattersAndPrinciples_ConsoleApp.csproj", "{2B034741-427C-4412-A0EB-D6DD3E08275A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/Document.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/Document.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation
+{
+    public class Document
+    {
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/MultiFunctionFilter.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/MultiFunctionFilter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation
+{
+    public class MultiFunctionFilter : IMachine
+    {
+        public void Print(Document d)
+        {
+            //
+        }
+        public void Scan(Document d)
+        {
+            //
+        }
+        public void Fax(Document d)
+        {
+            //
+        }
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/MultiFunctionMachine.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/MultiFunctionMachine.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation
+{
+    public class MultiFunctionMachine : IMultiFunctionDevice
+    {
+        private IPrinter Printer;
+        private IScanner Scanner;
+        public MultiFunctionMachine(IPrinter printer, IScanner scanner)
+        {
+            if(printer == null)
+            {
+                throw new ArgumentNullException(paramName: nameof(Printer));
+            }
+            if(scanner == null)
+            {
+                throw new ArgumentNullException(paramName: nameof(Scanner));
+            }
+            Printer = printer;
+            Scanner = scanner;
+        }
+        public void Print(Document d)
+        {
+            Printer.Print(d);
+        }
+
+        public void Scan(Document d)
+        {
+            Scanner.Scan(d);
+        }
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/OldFationFilter.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/OldFationFilter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation
+{
+    public class OldFationFilter : IMachine
+    {
+        public void Print(Document d)
+        {
+            //
+        }
+        public void Scan(Document d)
+        {
+            throw new NotImplementedException();
+        }
+        public void Fax(Document d)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/Photocopier.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/Photocopier.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation
+{
+    public class Photocopier : IPrinter, IScanner
+    {
+        public void Print(Document d)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Scan(Document d)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IFax.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IFax.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces
+{
+    public interface IFax
+    {
+        void Fax(Document d);
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IMachine.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IMachine.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces
+{
+    public interface IMachine
+    {
+        void Print(Document d);
+        void Scan(Document d);
+        void Fax(Document d);
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IMultiFunctionDevice.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IMultiFunctionDevice.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces
+{
+    public interface IMultiFunctionDevice : IPrinter, IScanner
+    {
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IPrinter.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IPrinter.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces
+{
+    public interface IPrinter
+    {
+        void Print(Document d);
+    }
+}

--- a/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IScanner.cs
+++ b/UDemy_DesignnPattersAndPrinciples_ConsoleApp/InterfaceSegregation/interfaces/IScanner.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace UDemy_DesignnPattersAndPrinciples_ConsoleApp.InterfaceSegregation.interfaces
+{
+    public interface IScanner
+    {
+        void Scan(Document d);
+    }
+}


### PR DESCRIPTION
Clients should not be forced to implement any methods they don't use.